### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.DS_Store


### PR DESCRIPTION
**PR title**
chore: ignore .DS_Store

**PR description**

## Summary

Adds `.DS_Store` to `.gitignore` so macOS Finder metadata files are not committed.

## Changes

* added `.DS_Store` to `.gitignore`
* optionally removed already tracked `.DS_Store` files from Git index

## Why

`.DS_Store` is a local macOS system file and should not be versioned.

## Testing

* confirmed `.DS_Store` is ignored by Git
* confirmed repository changes are limited to ignore/cleanup only
